### PR TITLE
Fix emoji chat to send messages to all clients

### DIFF
--- a/an_website/emoji_chat/chat.py
+++ b/an_website/emoji_chat/chat.py
@@ -86,7 +86,9 @@ async def save_new_message(
     await redis.ltrim(
         f"{redis_prefix}:emoji-chat:message-list", -MAX_MESSAGE_SAVE_COUNT, -1
     )
-    await redis.publish(REDIS_CHANNEL, json.dumps(message_dict, option=ORJSON_OPTIONS))
+    await redis.publish(
+        REDIS_CHANNEL, json.dumps(message_dict, option=ORJSON_OPTIONS)
+    )
 
 
 async def get_messages(

--- a/an_website/utils/background_tasks.py
+++ b/an_website/utils/background_tasks.py
@@ -29,6 +29,7 @@ from tornado.web import Application
 
 from .. import EVENT_ELASTICSEARCH, EVENT_REDIS, EVENT_SHUTDOWN
 from .elasticsearch_setup import setup_elasticsearch_configs
+from an_website.emoji_chat.chat import subscribe_to_redis_channel
 
 if TYPE_CHECKING:
     from .utils import ModuleInfo
@@ -155,6 +156,7 @@ def start_background_tasks(  # pylint: disable=too-many-arguments
         )
         .chain([check_elasticsearch] if elasticsearch_is_enabled else ())
         .chain([check_redis] if redis_is_enabled else ())
+        .chain([subscribe_to_redis_channel])
         .distinct()
         .peek(
             PEAK_FUNC

--- a/an_website/utils/background_tasks.py
+++ b/an_website/utils/background_tasks.py
@@ -27,9 +27,10 @@ from elasticsearch import AsyncElasticsearch
 from redis.asyncio import Redis
 from tornado.web import Application
 
+from an_website.emoji_chat.chat import subscribe_to_redis_channel
+
 from .. import EVENT_ELASTICSEARCH, EVENT_REDIS, EVENT_SHUTDOWN
 from .elasticsearch_setup import setup_elasticsearch_configs
-from an_website.emoji_chat.chat import subscribe_to_redis_channel
 
 if TYPE_CHECKING:
     from .utils import ModuleInfo


### PR DESCRIPTION
Modify the emoji chat to send new messages to all clients, regardless of the worker they are connected to.

* **an_website/emoji_chat/chat.py**
  - Add `REDIS_CHANNEL` constant for the Redis channel name.
  - Modify `save_new_message` to publish messages to the Redis channel.
  - Add `subscribe_to_redis_channel` function to handle incoming messages.
  - Modify `ChatWebSocketHandler` to subscribe to the Redis channel on connection.

* **an_website/utils/background_tasks.py**
  - Import `subscribe_to_redis_channel` from `an_website/emoji_chat/chat.py`.
  - Add `subscribe_to_redis_channel` to the list of background tasks.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/asozialesnetzwerk/an-website?shareId=21621921-b2de-475c-96d2-a41fba6f5154).